### PR TITLE
Fix `get()` and `[]` on object bound to read-only mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,4 +415,8 @@ After you first set up your virtual environment with Poetry, run this command to
 
 ### 0.1.1 - 2023-02-22:
 
-- Relax `Binder.bind()` argument type to `Mapping`
+- Relax `Binder.bind()` argument type to `Mapping` (#3)
+
+### 0.1.2 - 2023-03-03:
+
+- Fix `get()` and `[]` on object bound to read-only mapping (#6)

--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -16,7 +16,7 @@ from importlib import import_module
 from inspect import cleandoc, get_annotations, getmodule, getsource, isabstract
 from pathlib import Path
 from textwrap import dedent
-from types import ModuleType, NoneType, UnionType
+from types import MappingProxyType, ModuleType, NoneType, UnionType
 from typing import Any, BinaryIO, ClassVar, Generic, TypeVar, Union, cast, get_args, get_origin
 from weakref import WeakKeyDictionary
 
@@ -245,7 +245,7 @@ class Binder(Generic[T]):
             key_type, elem_type = get_args(field_type)
             mapping = {key: cls._bind_to_field(elem, elem_type, f'{context}["{key}"]') for key, elem in value.items()}
             return (
-                (mapping if isinstance(origin, MutableMapping) else mapping.items())
+                (mapping if isinstance(origin, MutableMapping) else MappingProxyType(mapping))
                 if isabstract(origin)
                 else field_type(mapping)
             )

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -492,6 +492,24 @@ def test_bind_mapping_ok() -> None:
     assert dict(config.magic_numbers) == {"the-answer": 42, "the-beast": 666, "haxor": 1337}
 
 
+def test_bind_mapping_access() -> None:
+    """Bound Mappings support read-only access."""
+    with stream_text(
+        """
+        magic-numbers = {the-answer = 42, "the-beast" = 666, haxor = 1337}
+        """
+    ) as stream:
+        config = Binder[MappingConfig].parse_toml(stream)
+
+    assert isinstance(config.magic_numbers, Mapping)
+    assert config.magic_numbers.get("the-answer") == 42
+    assert config.magic_numbers["the-beast"] == 666
+    assert config.magic_numbers.get("missingno") is None
+
+    with raises(TypeError):
+        config.magic_numbers["suitcase"] = 12345  # type: ignore[index]
+
+
 def test_bind_mapping_nontable() -> None:
     """TypeError is raised when the value for a mapping field is not a table."""
 


### PR DESCRIPTION
Closes: #6 