### PR TITLE
Ignore dataclass fields with `init=False`

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,3 +420,7 @@ After you first set up your virtual environment with Poetry, run this command to
 ### 0.1.2 - 2023-03-03:
 
 - Fix `get()` and `[]` on object bound to read-only mapping ([#6](https://github.com/ProtixIT/dataclass-binder/issues/6))
+
+### 0.1.3 - 2023-03-05:
+
+- Ignore dataclass fields with `init=False` ([#2](https://github.com/ProtixIT/dataclass-binder/issues/2))

--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -1,6 +1,4 @@
-"""
-TODO: Ignore fields with init=False.
-"""
+"""Implementation module."""
 
 from __future__ import annotations
 
@@ -562,6 +560,9 @@ def format_template(class_or_instance: Any) -> Iterator[str]:
 
     first = True
     for field in fields(config_class):
+        if not field.init:
+            continue
+
         if first:
             first = False
         else:

--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -160,12 +160,17 @@ def _get_fields(cls: type) -> Iterator[tuple[str, type]]:
     This includes fields inherited from superclasses.
     """
 
+    fields_by_name = {field.name: field for field in fields(cls)}
+
     # Note: getmodule() can return None, but the end result is still fine.
     cls_globals = getattr(getmodule(cls), "__dict__", {})
     cls_locals = vars(cls)
 
     for field_container in reversed(cls.__mro__):
         for name, annotation in get_annotations(field_container).items():
+            field = fields_by_name[name]
+            if not field.init:
+                continue
             if isinstance(annotation, str):
                 try:
                     annotation = eval(annotation, cls_globals, cls_locals)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
 from io import BytesIO
 from types import ModuleType
@@ -204,6 +204,9 @@ class TemplateConfig:
     """
 
     multi_type: str | int
+
+    derived: int = field(init=False)
+    """Excluded field."""
 
     bad_annotation: NoSuchType  # type: ignore[name-defined]  # noqa
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -893,9 +893,12 @@ def test_specialize_annotation_nested_scope() -> None:
 def test_specialize_excluded_from_init() -> None:
     """Fields with `init=False` are ignored at specialization."""
 
+    class CustomType:
+        pass
+
     @dataclass
     class Config:
-        unsupported: Exception = field(init=False)
+        unsupported: CustomType = field(init=False)
 
     Binder[Config]
 
@@ -917,5 +920,6 @@ def test_bind_excluded_from_init() -> None:
     assert config.total == 10
 
     with stream_text("total = 9001") as stream:
-        with raises(TypeError, match=r"unexpected keyword argument 'total'"):
+        # TODO: Refine error message: the field does exist, but it's excluded.
+        with raises(ValueError, match=r"^Field 'SumConfig\.total' does not exist$"):
             Binder[SumConfig].parse_toml(stream)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -869,6 +869,27 @@ def test_bind_dataclass_in_sequence() -> None:
     assert config.trends[1].trend_identifier == "uprising attempts"
 
 
+def test_specialize_annotation_nested_scope() -> None:
+    """
+    Handle an annotation using a name from a nested scope gracefully.
+
+    Python does not record nested scopes for class definitions.
+    This means we have no way of resolving names from nested scopes used in annotations.
+    All we can do is report the problem field.
+    """
+
+    @dataclass
+    class Hidden:
+        pass
+
+    @dataclass
+    class Config:
+        hidden: Hidden
+
+    with raises(TypeError, match=r"^Failed to parse annotation of field 'Config\.hidden': "):
+        Binder[Config]
+
+
 def test_specialize_excluded_from_init() -> None:
     """Fields with `init=False` are ignored at specialization."""
 


### PR DESCRIPTION
As the excluded fields should be skipped during the evaluation of annotation strings, that evaluation is now done by our code instead of `inspect.get_annotations()`. That change also allows for a more detailed error message when a name from a nested scope is used in an annotation.
