### PR TITLE
Replace flake8 by Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-max-line-length: 120
-# E203: whitespace before ':'
-#       Black and flake8 disagree on how slices should be formatted.
-ignore: E203

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,11 @@ repos:
     rev: 22.12.0
     hooks:
     -   id: black
--   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-    -   id: flake8
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
     -   id: isort
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.274
+    hooks:
+    -   id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,8 @@ exclude_lines = [
     # Intended to be unreachable:
     "raise NotImplementedError$",
     "raise NotImplementedError\\(",
+    "raise AssertionError$",
+    "raise AssertionError\\(",
     "assert False$",
     "assert False,",
     # Debug-only code:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ pre-commit = "^2.20.0"
 mypy = "^1.0"
 pytest = "^7.2.0"
 pytest-cov = "^4.0.0"
+ruff = "0.0.274"
 
 [tool.poetry.group.coverage.dependencies]
 coverage = {version = "^7.0.0", extras = ["toml"]}
@@ -38,6 +39,11 @@ target-version = ["py310"]
 profile = "black"
 multi_line_output = 3
 line_length = 120
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+src = ["src"]
 
 [tool.mypy]
 disallow_incomplete_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,17 @@ line_length = 120
 line-length = 120
 target-version = "py310"
 src = ["src"]
+select = [
+    "F", "E", "W", "I", "N", "UP", "ANN0", "ANN2", "FBT", "B", "A", "C4", "FA",
+    "ISC", "ICN", "G", "INP", "PIE", "T20", "PT", "Q", "RSE", "RET", "SLF", "SIM",
+    "ARG", "ERA", "PGH", "PLC", "PLE", "PLW", "TRY", "FLY", "RUF",
+]
+ignore = [
+    "PT007",  # not using tuples for single argument helps readability
+    "RET505", "RET506",  # not sure following that style improves readability
+    "PLW2901",  # overwriting the loop variable is sometimes useful
+    "TRY003",  # maybe in the future
+]
 
 [tool.mypy]
 disallow_incomplete_defs = true


### PR DESCRIPTION
Ruff comes with a huge number of extra rules built-in, while flake8 needs plugins for them.

Ruff is also fast enough to enable checks as you type in an IDE, instead of only on save or commit.