### PR TITLE
Support instantiating `Binder` from a dataclass object

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,22 @@ class Config:
     limits: Mapping[str, int]
 ```
 
+### Layered Binding
+
+`Binder` can be instantiated from a dataclass object rather than the dataclass itself.
+The dataclass object will provide new default values when binding data to it.
+This can be used to implement a layered configuration parsing mechanism, where there is a default configuration that can be customized using a system-wide configuration file and/or a per-user configuration file:
+
+```py
+config = Config()
+if system_config_path.exists():
+    config = Binder(config).parse_toml(system_config_path)
+if user_config_path.exists():
+    config = Binder(config).parse_toml(user_config_path)
+```
+
+Later layers can override individual fields in nested dataclasses, allowing fine-grained configuration merging, but collections are replaced whole instead of merged.
+
 ### Generating a Configuration Template
 
 To provide users with a starting point for configuring your application/service, you can automatically generate a configuration template from the information in the dataclass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ ignore = [
     "RET505", "RET506",  # not sure following that style improves readability
     "PLW2901",  # overwriting the loop variable is sometimes useful
     "TRY003",  # maybe in the future
+    "TRY301",  # alternatives might be worse
 ]
 
 [tool.mypy]

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -125,6 +125,13 @@ def test_bind_file(tmp_path: Path) -> None:
     assert config.import_max_nr_hours == 24
 
 
+def test_bind_dataclass_instance() -> None:
+    instance = Config(rest_api_port=6000)
+    binder = Binder(instance)
+    assert binder._dataclass is Config
+    assert binder._instance is instance
+
+
 def test_bind_inheritance() -> None:
     """A dataclass inheriting from another dataclass accepts fields from both the base and the subclass."""
 


### PR DESCRIPTION
This implements the foundation of #17, but doesn't change the way `format_template()` works yet.