### PR TITLE
Fix formatting of `init=False` field in nested dataclasses

### DIFF
--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -474,6 +474,8 @@ def _to_toml_pair(value: object) -> tuple[str | None, Any]:
         case _ if is_dataclass(value):
             table = {}
             for field in fields(value):
+                if not field.init:
+                    continue
                 name = field.name
                 sub_value = getattr(value, name)
                 if sub_value is None:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -210,6 +210,7 @@ def test_format_value_dict_suffix(*, optional: bool, string: bool) -> None:
 class Inner:
     key_containing_underscores: bool
     maybesuffix: timedelta
+    behind_the_curtain: str = field(init=False, default="wizard")
 
 
 @pytest.mark.parametrize("optional", (True, False))


### PR DESCRIPTION
Fields with `init=False` were ignored when formatting a top-level dataclass, but not yet in a nested dataclass.