### PR TITLE
Omit values that are formatted equally to the default

### DIFF
--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -561,6 +561,11 @@ class Table(Generic[T]):
         return replace(self, key_fmt=f"{context}.{self.key_fmt}" if context else self.key_fmt)
 
     def format_table(self, inside: Set[type]) -> Iterator[str]:
+        """
+        The `inside` parameter keeps track of which dataclasses we are currently outputting,
+        to prevent infinite recursion.
+        """
+
         child_tables: list[Table[Any]] = []
         context = self.key_fmt
         value = self.value
@@ -574,7 +579,6 @@ class Table(Generic[T]):
                 case _:
                     content = []
         elif value is None and binder._dataclass in inside:
-            # Prevent infinite recursion.
             content = None
         else:
             inside |= {binder._dataclass}

--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -499,12 +499,12 @@ class Binder(Generic[T]):
             yield ""
 
             comments = [docstring]
-            if value == default:
-                value = None
             if not optional or default is None:
+                fmt_default = None
                 comments.append("Optional." if default is None else "Mandatory.")
             else:
-                comments.append(f"Default:\n{format_toml_pair(key, default)}")
+                fmt_default = format_toml_pair(key, default)
+                comments.append(f"Default:\n{fmt_default}")
             yield from _format_comments(*comments)
 
             if value is None:
@@ -514,7 +514,9 @@ class Binder(Generic[T]):
                     value_fmt = _format_value_for_type(field_type)
                     yield f"{comment}{key_fmt} = {value_fmt}"
             else:
-                yield f"{format_toml_pair(key, value)}"
+                fmt_value = format_toml_pair(key, value)
+                if fmt_value != fmt_default:
+                    yield fmt_value
 
     if TYPE_CHECKING:
         # These definitions exist to support the deprecated `Binder[DC]` syntax in mypy.

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -489,6 +489,27 @@ numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     )
 
 
+def test_format_template_sequence_default() -> None:
+    """
+    When formatting, a sequence value is considered equal to the default if it would produce identical TOML,
+    even if the Python type is different.
+    """
+
+    @dataclass
+    class Config:
+        things: Sequence[str] = ("this", "that")
+
+    config = Config(things=["this", "that"])
+
+    template = "\n".join(Binder(config).format_toml_template())
+    assert template == (
+        """
+# Default:
+# things = ['this', 'that']
+""".strip()
+    )
+
+
 def test_format_template_sequence_nested_class() -> None:
     @dataclass
     class Config:


### PR DESCRIPTION
This avoids outputting a value with equal to the default in cases where the Python object is unequal but the TOML representation is, for example when the default is a `tuple` but the actual value is a `list` containing the same elements.

Closes #32