### PR TITLE
Add non-template TOML formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,43 @@ database-url = 'postgresql://<username>:<password>@<hostname>/<database name>'
 port = 8080
 ```
 
+### Generating a Compact Configuration File
+
+If you want to generate a fully populated configuration, you can use the `format_toml()` method.
+Compared to the template formatting, this leaves out optional parts for which no data has been provided.
+
+For example, when the following dataclass defines your configuration:
+
+```py
+@dataclass
+class Config:
+    path: str
+    """Path of input file."""
+
+    verbose: bool = False
+    """Be extra verbose in logging."""
+
+    options: dict[str, Any] = field(default_factory=dict)
+    """Various named options that are passed on to tool XYZ."""
+```
+
+This code generates a populated configuration file:
+
+```py
+config = Config(path="./data")
+
+with open("config.toml", "w") as out:
+    for line in Binder(config).format_toml():
+        print(line, file=out)
+```
+
+With the contents of `config.toml` containing only the `path` field:
+
+```toml
+# Path of input file.
+path = './data'
+```
+
 ### Troubleshooting
 
 Finally, a troubleshooting tip: instead of the full `Binder(Config).parse_toml()`, first try to execute only `Binder(Config)`.

--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -512,11 +512,11 @@ class Binder(Generic[T]):
 
             comments = [docstring]
             if not optional or default is None:
-                fmt_default = None
+                default_fmt = None
                 comments.append("Optional." if default is None else "Mandatory.")
             else:
-                fmt_default = format_toml_pair(key, default)
-                comments.append(f"Default:\n{fmt_default}")
+                default_fmt = format_toml_pair(key, default)
+                comments.append(f"Default:\n{default_fmt}")
             yield from _format_comments(*comments)
 
             if value is None:
@@ -526,9 +526,9 @@ class Binder(Generic[T]):
                     value_fmt = _format_value_for_type(field_type)
                     yield f"{comment}{key_fmt} = {value_fmt}"
             else:
-                fmt_value = format_toml_pair(key, value)
-                if fmt_value != fmt_default:
-                    yield fmt_value
+                actual_fmt = format_toml_pair(key, value)
+                if actual_fmt != default_fmt:
+                    yield actual_fmt
 
     if TYPE_CHECKING:
         # These definitions exist to support the deprecated `Binder[DC]` syntax in mypy.

--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -531,8 +531,7 @@ class Binder(Generic[T]):
             else:
                 # We have no value; we do have a default but it's unformattable.
                 comments.append(f"Optional.\n{key_fmt} = {_format_value_for_type(field_type)}")
-            yield ""
-            yield from _format_comments(*comments)
+            yield from _format_comments(*comments, leading_newline=True)
 
             if value_fmt is not None:
                 yield value_fmt
@@ -783,10 +782,22 @@ def _iter_format_value(value: object) -> Iterator[str]:
             raise TypeError(type(value).__name__)
 
 
-def _format_comments(*comments: str | None) -> Iterator[str]:
+def _format_comments(*comments: str | None, leading_newline: bool = False) -> Iterator[str]:
+    """
+    Yield lines containing a formatted version of the given comments.
+
+    Comments that are None will be ignored.
+    If `leading_newline` is True, an empty ine will be output before any comment lines,
+    but only if the output is non-empty.
+    """
+
     separator = False
     for comment in comments:
         if comment:
+            if leading_newline:
+                yield ""
+                leading_newline = False
+
             contains_empty = False
             for line in comment.split("\n"):
                 if separator:

--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -627,7 +627,7 @@ class Table(Generic[T]):
 
         if content is not None:
             if context:
-                yield from self.format_header()
+                yield from self.format_header(template=template)
 
             yield from content
 
@@ -635,12 +635,12 @@ class Table(Generic[T]):
             if template or table.value is not None:
                 yield from table.prefix_context(context).format_table(inside, template=template)
 
-    def format_header(self) -> Iterator[str]:
+    def format_header(self, *, template: bool) -> Iterator[str]:
         yield ""
         yield from _format_comments(
             self.class_docstring,
             self.field_docstring,
-            "Optional table." if self.optional else None,
+            "Optional table." if template and self.optional else None,
         )
         yield f"[{self.key_fmt}]"
 

--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -522,7 +522,6 @@ class Binder(Generic[T]):
             if value is None:
                 if not optional or default is None:
                     comment = "# " if default is None else ""
-                    key_fmt = "".join(_iter_format_key(key))
                     value_fmt = _format_value_for_type(field_type)
                     yield f"{comment}{key_fmt} = {value_fmt}"
             else:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -630,7 +630,7 @@ def test_format_template_valid_value(*, field_type: type[Any], optional: bool, s
 class MiddleConfig:
     """This docstring will remain invisible, as its table is empty."""
 
-    deepest: NestedConfig
+    deepest: NestedConfig | None = None
 
 
 @dataclass(kw_only=True)
@@ -668,6 +668,7 @@ source-database-connection-url = 'postgresql://<username>:<password>@<hostname>/
 webhook-urls = ['https://host1/refresh', 'https://host2/refresh']
 
 # This table is bound to a nested dataclass.
+# Optional table.
 [middle.deepest]
 
 # Mandatory.

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -713,13 +713,24 @@ def test_format_optional_tables() -> None:
 
     @dataclass
     class Config:
-        untyped: dict[str, Any]
-        """This is the docstring for the untyped field."""
+        untyped_mandatory: dict[str, Any]
+        """This is the docstring for the mandatory untyped field."""
+
+        untyped_optional: dict[str, Any] = field(default_factory=dict)
+        """This is the docstring for the optional untyped field."""
 
         nested: NestedConfig | None = None
         """Optional nested dataclass."""
 
-    assert list(Binder(Config).format_toml()) == []
+    expected = """
+# This is the docstring for the mandatory untyped field.
+[untyped-mandatory]
+""".strip()
+
+    assert "\n".join(Binder(Config).format_toml()) == expected
+
+    config = Config(untyped_mandatory={})
+    assert "\n".join(Binder(config).format_toml()) == expected
 
 
 @dataclass


### PR DESCRIPTION
A configuration template is useful as a starting point for a manually crafted configuration. However, in some cases we want to automatically produce a full configuration that doesn't require manual editing. In those cases, we want just the given data to end up in the output and no examples for optional elements that could have been configured but weren't.

This PR adds a `format_toml()` method, which operates similar to `format_toml_template()` but leaves out optional elements unless there is data present for them.

The output of `format_toml()` when called on a `Binder` that wraps a dataclass _instance_ is guaranteed to be valid TOML. That guarantee doesn't hold when a dataclass itself is wrapped, because there is no data to put into mandatory fields then.