### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
Now that Python 3.12 has been released, we should support it.

Fortunately, no changes are needed other than including 3.12 in the CI matrix.