### PR TITLE
Add support for Enums #29

### DIFF
--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -19,7 +19,7 @@ from collections.abc import (
 )
 from dataclasses import MISSING, Field, asdict, dataclass, fields, is_dataclass, replace
 from datetime import date, datetime, time, timedelta
-from enum import Enum, ReprEnum
+from enum import Enum
 from functools import reduce
 from importlib import import_module
 from inspect import cleandoc, get_annotations, getmodule, getsource, isabstract
@@ -31,7 +31,19 @@ from weakref import WeakKeyDictionary
 
 if sys.version_info < (3, 11):
     import tomli as tomllib  # pragma: no cover
+
+    if TYPE_CHECKING:
+
+        class ReprEnum(Enum):
+            ...
+
+    else:
+        from enum import IntEnum, IntFlag
+
+        ReprEnum = IntEnum | IntFlag
 else:
+    from enum import ReprEnum
+
     import tomllib  # pragma: no cover
 
 
@@ -707,9 +719,10 @@ def _to_toml_pair(value: object) -> tuple[str | None, Any]:
                 else:
                     return "-days", days
         case Enum():
-            return None, value.name.lower()
-        case ReprEnum():
-            return None, value.value
+            if isinstance(value, ReprEnum):
+                return None, value.value
+            else:
+                return None, value.name.lower()
         case ModuleType():
             return None, value.__name__
         case Mapping():

--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -29,8 +29,8 @@ from types import MappingProxyType, ModuleType, NoneType, UnionType
 from typing import TYPE_CHECKING, Any, BinaryIO, ClassVar, Generic, TypeVar, Union, cast, get_args, get_origin, overload
 from weakref import WeakKeyDictionary
 
-if sys.version_info < (3, 11):
-    import tomli as tomllib  # pragma: no cover
+if sys.version_info < (3, 11):  # pragma: no cover
+    import tomli as tomllib
 
     if TYPE_CHECKING:
 
@@ -41,10 +41,9 @@ if sys.version_info < (3, 11):
         from enum import IntEnum, IntFlag
 
         ReprEnum = IntEnum | IntFlag
-else:
+else:  # pragma: no cover
+    import tomllib  # noqa: I001
     from enum import ReprEnum
-
-    import tomllib  # pragma: no cover
 
 
 def _collect_type(field_type: type, context: str) -> type | Binder[Any]:

--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -210,7 +210,6 @@ T = TypeVar("T")
 
 @dataclass(slots=True)
 class _ClassInfo(Generic[T]):
-
     _cache: ClassVar[MutableMapping[type[Any], _ClassInfo[Any]]] = WeakKeyDictionary()
 
     dataclass: type[T]

--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -689,6 +689,13 @@ def format_toml_pair(key: str, value: object) -> str:
 def _to_toml_pair(value: object) -> tuple[str | None, Any]:
     """Return a TOML-compatible suffix and value pair with the data from the given rich value object."""
     match value:
+        # enums have to be checked before basic types because for instance
+        # IntEnum is also of type int
+        case Enum():
+            if isinstance(value, ReprEnum):
+                return None, value.value
+            else:
+                return None, value.name.lower()
         case str() | int() | float() | date() | time() | Path():  # note: 'bool' is a subclass of 'int'
             return None, value
         case timedelta():
@@ -718,11 +725,6 @@ def _to_toml_pair(value: object) -> tuple[str | None, Any]:
                     return "-weeks", days // 7
                 else:
                     return "-days", days
-        case Enum():
-            if isinstance(value, ReprEnum):
-                return None, value.value
-            else:
-                return None, value.name.lower()
         case ModuleType():
             return None, value.__name__
         case Mapping():

--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -61,7 +61,7 @@ def _collect_type(field_type: type, context: str) -> type | Binder[Any]:
             return object
         elif not isinstance(field_type, type):
             raise TypeError(f"Annotation for field '{context}' is not a type")
-        elif issubclass(field_type, str | int | float | date | time | timedelta | ModuleType | Path | Enum | ReprEnum):
+        elif issubclass(field_type, str | int | float | date | time | timedelta | ModuleType | Path | Enum):
             return field_type
         elif field_type is type:
             # https://github.com/python/mypy/issues/13026
@@ -326,14 +326,23 @@ class Binder(Generic[T]):
                     raise TypeError(f"Expected TOML string for path '{context}', got '{type(value).__name__}'")
                 return field_type(value)
             elif issubclass(field_type, ReprEnum):
+                if issubclass(field_type, int) and not isinstance(value, int):
+                    raise TypeError(f"Value for '{context}': '{value}' is not of type int")
+                if issubclass(field_type, str) and not isinstance(value, str):
+                    raise TypeError(f"Value for '{context}': '{value}' is not of type str")
                 return field_type(value)
             elif issubclass(field_type, Enum):
                 if not isinstance(value, str):
-                    raise TypeError(f"'{value}' is not a valid key for enum '{field_type}', must be of type str")
+                    raise TypeError(
+                        f"Value for '{context}': '{value}' is not a valid key for enum '{field_type}', "
+                        f"must be of type str"
+                    )
                 for enum_value in field_type:
                     if enum_value.name.lower() == value.lower():
                         return enum_value
-                raise TypeError(f"'{value}' is not a valid key for enum '{field_type}', could not be found")
+                raise TypeError(
+                    f"Value for '{context}': '{value}' is not a valid key for enum '{field_type}', could not be found"
+                )
             elif isinstance(value, field_type) and (
                 type(value) is not bool or field_type is bool or field_type is object
             ):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
-from enum import Enum, auto, IntEnum
+from enum import Enum, IntEnum, auto
 from io import BytesIO
 from pathlib import Path
 from types import ModuleType, NoneType, UnionType
@@ -887,8 +887,8 @@ def test_format_with_enums() -> None:
 
     assert template == (
         """
-message = "Hello, World"
-verbosity = "detailed"
-verbosity-evel = 2
+message = 'Hello, World'
+verbosity = 'detailed'
+verbosity-level = 2
 """.strip()
     )

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
-from enum import Enum
+from enum import Enum, auto, IntEnum
 from io import BytesIO
 from pathlib import Path
 from types import ModuleType, NoneType, UnionType
@@ -862,27 +862,33 @@ value = 0
     )
 
 
-class IssueStatus(Enum):
-    OPEN = "open"
-    REJECTED = "rejected"
-    COMPLETED = "completed"
+class Verbosity(Enum):
+    QUIET = auto()
+    NORMAL = auto()
+    DETAILED = auto()
+
+
+class IntVerbosity(IntEnum):
+    QUIET = 0
+    NORMAL = 1
+    DETAILED = 2
 
 
 def test_format_with_enums() -> None:
     @dataclass
-    class Issue:
-        issue_id: int
-        title: str
-        status: IssueStatus
+    class Log:
+        message: str
+        verbosity: Verbosity
+        verbosity_level: IntVerbosity
 
-    issue = Issue(1, "Test", IssueStatus.OPEN)
+    log = Log("Hello, World", Verbosity.DETAILED, IntVerbosity.DETAILED)
 
-    template = "\n".join(Binder(issue).format_toml())
+    template = "\n".join(Binder(log).format_toml())
 
     assert template == (
         """
-issue-id = 1
-title = 'Test'
-status = 'open'
+message = "Hello, World"
+verbosity = "detailed"
+verbosity-evel = 2
 """.strip()
     )

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -871,7 +871,7 @@ class IssueStatus(Enum):
 def test_format_with_enums() -> None:
     @dataclass
     class Issue:
-        id: int
+        issue_id: int
         title: str
         status: IssueStatus
 
@@ -880,7 +880,7 @@ def test_format_with_enums() -> None:
     template = "\n".join(Binder(issue).format_toml())
 
     assert template == """
-id = 1
+issue-id = 1
 title = 'Test'
 status = 'open'
 """.strip()

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -862,55 +862,25 @@ value = 0
     )
 
 
-class Color(Enum):
-    RED = "red"
-    BLUE = "blue"
-    GREEN = "green"
+class IssueStatus(Enum):
+    OPEN = "open"
+    REJECTED = "rejected"
+    COMPLETED = "completed"
 
-class Number(Enum):
-    ONE = 1
-    TWO = 2
-    THREE = 3
 
-@dataclass
-class EnumEntry:
-    name: str
-    color: Color
-    number: Number
-
-def test_enums() -> None:
+def test_format_with_enums() -> None:
     @dataclass
-    class Config:
-        best_colors: list[Color]
-        best_numbers: list[Number]
-        entries: list[EnumEntry]
+    class Issue:
+        id: int
+        title: str
+        status: IssueStatus
 
-    with stream_text(
-        """
-        best-colors = ["red", "green", "blue"]
-        best-numbers = [1, 2, 3]
+    issue = Issue(1, "Test", IssueStatus.OPEN)
 
-        [[entries]]
-        name = "Entry 1"
-        color = "blue"
-        number = 2
+    template = "\n".join(Binder(issue).format_toml())
 
-        [[entries]]
-        name = "Entry 2"
-        color = "red"
-        number = 1
-        """
-    ) as stream:
-        config = Binder(Config).parse_toml(stream)
-
-    assert len(config.best_colors) == 3
-    assert len(config.best_numbers) == 3
-    assert config.best_colors.index(Color.RED) == 0
-    assert config.best_colors.index(Color.GREEN) == 1
-    assert config.best_colors.index(Color.BLUE) == 2
-    assert all(num in config.best_numbers for num in Number)
-    assert len(config.entries) == 2
-    assert config.entries[0].color == Color.BLUE
-    assert config.entries[0].number == Number.TWO
-    assert config.entries[1].color == Color.RED
-    assert config.entries[1].number == Number.ONE
+    assert template == """
+id = 1
+title = 'Test'
+status = 'open'
+""".strip()

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
+from enum import Enum
 from io import BytesIO
 from pathlib import Path
 from types import ModuleType, NoneType, UnionType
@@ -859,3 +860,57 @@ def test_format_template_no_module(sourceless_class: type[Any]) -> None:
 value = 0
 """.strip()
     )
+
+
+class Color(Enum):
+    RED = "red"
+    BLUE = "blue"
+    GREEN = "green"
+
+class Number(Enum):
+    ONE = 1
+    TWO = 2
+    THREE = 3
+
+@dataclass
+class EnumEntry:
+    name: str
+    color: Color
+    number: Number
+
+def test_enums() -> None:
+    @dataclass
+    class Config:
+        best_colors: list[Color]
+        best_numbers: list[Number]
+        entries: list[EnumEntry]
+
+    with stream_text(
+        """
+        best-colors = ["red", "green", "blue"]
+        best-numbers = [1, 2, 3]
+
+        [[entries]]
+        name = "Entry 1"
+        color = "blue"
+        number = 2
+
+        [[entries]]
+        name = "Entry 2"
+        color = "red"
+        number = 1
+        """
+    ) as stream:
+        config = Binder(Config).parse_toml(stream)
+
+    assert len(config.best_colors) == 3
+    assert len(config.best_numbers) == 3
+    assert config.best_colors.index(Color.RED) == 0
+    assert config.best_colors.index(Color.GREEN) == 1
+    assert config.best_colors.index(Color.BLUE) == 2
+    assert all(num in config.best_numbers for num in Number)
+    assert len(config.entries) == 2
+    assert config.entries[0].color == Color.BLUE
+    assert config.entries[0].number == Number.TWO
+    assert config.entries[1].color == Color.RED
+    assert config.entries[1].number == Number.ONE

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -879,8 +879,10 @@ def test_format_with_enums() -> None:
 
     template = "\n".join(Binder(issue).format_toml())
 
-    assert template == """
+    assert template == (
+        """
 issue-id = 1
 title = 'Test'
 status = 'open'
 """.strip()
+    )

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1144,6 +1144,42 @@ def test_enums() -> None:
     assert config.entries[1].number is Number.ONE
 
 
+def test_enum_with_invalid_value() -> None:
+    @dataclass
+    class UserFavorites:
+        favorite_number: Number
+        favorite_color: Color
+
+    with stream_text(
+        """
+        favorite-number = "one"
+        favorite-color = "red"
+        """
+    ) as stream, pytest.raises(ValueError):  # noqa: PT011
+        Binder(UserFavorites).parse_toml(stream)
+
+
+def test_enum_keys_being_case_insensitive() -> None:
+    @dataclass
+    class Theme:
+        primary: Color
+        secondary: Color
+        accent: Color
+
+    with stream_text(
+        """
+        primary = "RED"
+        secondary = "green"
+        accent = "blUE"
+        """
+    ) as stream:
+        theme = Binder(Theme).parse_toml(stream)
+
+    assert theme.primary is Color.RED
+    assert theme.secondary is Color.GREEN
+    assert theme.accent is Color.BLUE
+
+
 def test_key_based_enum_while_using_value_ident() -> None:
     @dataclass
     class UserColorPreference:
@@ -1152,9 +1188,8 @@ def test_key_based_enum_while_using_value_ident() -> None:
 
     with stream_text(
         """
-            primary = "#FF0000"
-            seconadry = "blue"
-            """
-    ) as stream:
-        with pytest.raises(TypeError):
-            Binder(UserColorPreference).parse_toml(stream)
+        primary = "#FF0000"
+        seconadry = "blue"
+        """
+    ) as stream, pytest.raises(TypeError):
+        Binder(UserColorPreference).parse_toml(stream)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1099,6 +1099,16 @@ class Number(IntEnum):
     THREE = 3
 
 
+class Weekday(Enum):
+    MONDAY = 0
+    TUESDAY = 1
+    WEDNESDAY = 2
+    THURSDAY = 3
+    FRIDAY = 4
+    SATURDAY = 5
+    SUNDAY = 6
+
+
 @dataclass
 class EnumEntry:
     name: str
@@ -1193,3 +1203,26 @@ def test_key_based_enum_while_using_value_ident() -> None:
         """
     ) as stream, pytest.raises(TypeError):
         Binder(UserColorPreference).parse_toml(stream)
+
+
+def test_enum_parsing_with_invalid_key_type() -> None:
+    @dataclass
+    class UserPrefs:
+        name: str
+        start_of_the_week: Weekday
+
+    with stream_text(
+        """
+        name = "Peter Testuser"
+        start-of-the-week = "sunday"
+        """
+    ) as stream:
+        Binder(UserPrefs).parse_toml(stream)
+
+    with stream_text(
+        """
+        name = "Peter Testuser"
+        start-of-the-week = 1
+        """
+    ) as stream, pytest.raises(TypeError):
+        Binder(UserPrefs).parse_toml(stream)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1142,3 +1142,19 @@ def test_enums() -> None:
     assert config.entries[0].number is Number.TWO
     assert config.entries[1].color is Color.RED
     assert config.entries[1].number is Number.ONE
+
+
+def test_key_based_enum_while_using_value_ident() -> None:
+    @dataclass
+    class UserColorPreference:
+        primary: Color
+        secondary: Color
+
+    with stream_text(
+        """
+            primary = "#FF0000"
+            seconadry = "blue"
+            """
+    ) as stream:
+        with pytest.raises(TypeError):
+            Binder(UserColorPreference).parse_toml(stream)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import FrozenInstanceError, dataclass, field
 from datetime import date, datetime, time, timedelta
+from enum import Enum
 from io import BytesIO
 from pathlib import Path
 from types import ModuleType
@@ -1084,3 +1085,60 @@ def test_bind_merge() -> None:
     assert merged_config.flag is True
     assert merged_config.nested1.value == "sun"
     assert merged_config.nested2.value == "cheese"
+
+
+class Color(Enum):
+    RED = "red"
+    BLUE = "blue"
+    GREEN = "green"
+
+
+class Number(Enum):
+    ONE = 1
+    TWO = 2
+    THREE = 3
+
+
+@dataclass
+class EnumEntry:
+    name: str
+    color: Color
+    number: Number
+
+
+def test_enums() -> None:
+    @dataclass
+    class Config:
+        best_colors: list[Color]
+        best_numbers: list[Number]
+        entries: list[EnumEntry]
+
+    with stream_text(
+        """
+        best-colors = ["red", "green", "blue"]
+        best-numbers = [1, 2, 3]
+
+        [[entries]]
+        name = "Entry 1"
+        color = "blue"
+        number = 2
+
+        [[entries]]
+        name = "Entry 2"
+        color = "red"
+        number = 1
+        """
+    ) as stream:
+        config = Binder(Config).parse_toml(stream)
+
+    assert len(config.best_colors) == 3
+    assert len(config.best_numbers) == 3
+    assert config.best_colors.index(Color.RED) == 0
+    assert config.best_colors.index(Color.GREEN) == 1
+    assert config.best_colors.index(Color.BLUE) == 2
+    assert all(num in config.best_numbers for num in Number)
+    assert len(config.entries) == 2
+    assert config.entries[0].color == Color.BLUE
+    assert config.entries[0].number == Number.TWO
+    assert config.entries[1].color == Color.RED
+    assert config.entries[1].number == Number.ONE

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import FrozenInstanceError, dataclass, field
 from datetime import date, datetime, time, timedelta
-from enum import Enum
+from enum import Enum, IntEnum
 from io import BytesIO
 from pathlib import Path
 from types import ModuleType
@@ -1088,12 +1088,12 @@ def test_bind_merge() -> None:
 
 
 class Color(Enum):
-    RED = "red"
-    BLUE = "blue"
-    GREEN = "green"
+    RED = "#FF0000"
+    GREEN = "#00FF00"
+    BLUE = "#0000FF"
 
 
-class Number(Enum):
+class Number(IntEnum):
     ONE = 1
     TWO = 2
     THREE = 3
@@ -1138,7 +1138,7 @@ def test_enums() -> None:
     assert config.best_colors.index(Color.BLUE) == 2
     assert all(num in config.best_numbers for num in Number)
     assert len(config.entries) == 2
-    assert config.entries[0].color == Color.BLUE
-    assert config.entries[0].number == Number.TWO
-    assert config.entries[1].color == Color.RED
-    assert config.entries[1].number == Number.ONE
+    assert config.entries[0].color is Color.BLUE
+    assert config.entries[0].number is Number.TWO
+    assert config.entries[1].color is Color.RED
+    assert config.entries[1].number is Number.ONE

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1165,7 +1165,7 @@ def test_enum_with_invalid_value() -> None:
         favorite-number = "one"
         favorite-color = "red"
         """
-    ) as stream, pytest.raises(ValueError):  # noqa: PT011
+    ) as stream, pytest.raises(TypeError):
         Binder(UserFavorites).parse_toml(stream)
 
 


### PR DESCRIPTION
I like to use enums in Python so this seemed important to me, I added a few ways to use enums to the tests.

The only thing missing would be being able to use enums as keys for dicts that seemed a lot more complicated so I didn't implement this. Although right now I think only strings and ints can be used for that either way. 

I was waiting in line for a coffee for like 30m so I hacked this together on my phone, I hope the tests actually pass 😅