### PR TITLE
Support TOML formatting with a non-empty context

### DIFF
--- a/src/dataclass_binder/_impl.py
+++ b/src/dataclass_binder/_impl.py
@@ -436,7 +436,7 @@ class Binder(Generic[T]):
         else:
             return replace(instance, **parsed)  # type: ignore[type-var]
 
-    def format_toml(self) -> Iterator[str]:
+    def format_toml(self, context: str = "") -> Iterator[str]:
         """
         Yield lines of TOML text for populating the dataclass or object that we are binding to.
 
@@ -444,11 +444,14 @@ class Binder(Generic[T]):
 
         If we are binding to a class, example values for mandatory fields will be derived from the field types;
         these example values can be syntactically incorrect placeholders.
+
+        The `context` parameter contains a dot-separated key path for the bound object/class:
+        this will be prefixed to all yielded TOML table names.
         """
 
-        return self._format_toml_root(template=False)
+        return self._format_toml_root(context=context, template=False)
 
-    def format_toml_template(self) -> Iterator[str]:
+    def format_toml_template(self, context: str = "") -> Iterator[str]:
         """
         Yield lines of TOML text as a template for populating the dataclass or object that we are binding to.
 
@@ -457,12 +460,15 @@ class Binder(Generic[T]):
 
         If we are binding to an object, values from that object will be used to populate the template.
         If we are binding to a class, example values will be derived from the field types.
+
+        The `context` parameter contains a dot-separated key path for the bound object/class:
+        this will be prefixed to all yielded TOML table names.
         """
 
-        return self._format_toml_root(template=True)
+        return self._format_toml_root(context=context, template=True)
 
-    def _format_toml_root(self, *, template: bool) -> Iterator[str]:
-        table = Table(self, "", self._instance, None)
+    def _format_toml_root(self, *, context: str, template: bool) -> Iterator[str]:
+        table = Table(self, context, self._instance, None)
         lines = table.format_table(set(), template=template)
         for line in lines:
             if line:


### PR DESCRIPTION
Since we support binding tables that are not at the root of a TOML file, it makes sense to also support formatting non-root tables. This is done by passing a `context` argument that is prefixed to all table names in the TOML output.

Both `Binder.format_toml()` and `Binder.format_toml_template()` now take a `context` argument, which defaults to the empty string, preserving the previous behavior.